### PR TITLE
redirect should be treated as a normal response

### DIFF
--- a/lib/jellyfish.rb
+++ b/lib/jellyfish.rb
@@ -54,7 +54,7 @@ module Jellyfish
 
     def request  ; @request ||= Rack::Request.new(env); end
     def forward  ; raise(Jellyfish::NotFound.new)     ; end
-    def found url; raise(Jellyfish::   Found.new(url)); end
+    def found url; Jellyfish::Found.new(url)          ; end
     alias_method :redirect, :found
 
     def path_info     ; env['PATH_INFO']      || '/'  ; end


### PR DESCRIPTION
Hi Godfat

Under our usage of jellyfish

```
Api::Server = Rack::Builder.new do
  use Api::MiddleError
  use Rack::Cache
  run Api::ServerCore.new
end
```

with the implementation of `Api::MiddleError` as

```
class Api::MiddleError
  handle Jellyfish::Found do |e|
    status  e.status
    headers e.headers
    body    e.body
  end
end
```

redirects in `Api::ServerCore` don't get cached by `Rack::Cache`, although `Rack::Cache` itself stats that its capable of caching it in "lib/rack/cache/response.rb" line 59.

Although apparently we can circumvent this by

```
get '/some_path' do
  headers_merge 'Location' => url
  status 302
end
```

would it be better if redirects are treated as normal responses instead of fly over exceptions?
