### PR TITLE
Fixes for New Relic instrumentation

### DIFF
--- a/lib/jellyfish/newrelic.rb
+++ b/lib/jellyfish/newrelic.rb
@@ -14,11 +14,10 @@ module Jellyfish
                argument
              end.to_s[1..-1]
       name = "#{env['REQUEST_METHOD']} #{path}"
-        # magic category: NewRelic::MetricParser::WebTransaction::Jellyfish
-      perform_action_with_newrelic_trace(:category => 'Controller/Jellyfish',
-                                         :path     => path                  ,
-                                         :name     => name                  ,
-                                         :request  => request               ,
+
+      perform_action_with_newrelic_trace(:category => :rack  ,
+                                         :name     => name   ,
+                                         :request  => request,
                                          :params   => request.params){super}
     end
   end


### PR DESCRIPTION
This should get the New Relic extension back into working order with recent versions of the Ruby agent (3.9.0 and later for certain). There were two basic changes.

One, the agent wasn't including `NewRelic::MetricParser` by default anymore, which caused `NameError` failures on startup. Luckily, we stopped including it because they aren't really necessary, so the Jellyfish class can just go away entirely. :tada: 

Second, something had shifted in the transaction naming through to `perform_action_with_newrelic_trace`, so I tightened that up. Specifically, the `category` expected a symbol in a known set of "web" categories, and passing `path` along with `name` resulted in skipping some naming machinery that it shouldn't have.

Here's what it looks like in the UI for me with these changes on a test app (with `Tank` having a route `/jellyfish`):

![image](https://cloud.githubusercontent.com/assets/130504/5251556/4b21555c-794b-11e4-800d-1ecddaacf2f7.png)
